### PR TITLE
Implement findCertificates function

### DIFF
--- a/src/ninja/getCertificates.js
+++ b/src/ninja/getCertificates.js
@@ -1,0 +1,24 @@
+const makeHttpRequest = require('../utils/makeHttpRequest')
+
+/**
+ * Returns found certificates
+ * @param {*} certifiers The certifiers to filter certificates by
+ * @param {*} types The certificate types to filter certificates by
+ * @returns {Promise<Object>} An object containing the found certificates
+ */
+module.exports = async (certifiers, types) => {
+  const result = await makeHttpRequest(
+    'http://localhost:3301/v1/ninja/findCertificates',
+    {
+      method: 'get',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: {
+        certifiers,
+        types
+      }
+    }
+  )
+  return result
+}

--- a/src/ninja/getCertificates.js
+++ b/src/ninja/getCertificates.js
@@ -10,7 +10,7 @@ module.exports = async (certifiers, types) => {
   const result = await makeHttpRequest(
     'http://localhost:3301/v1/ninja/findCertificates',
     {
-      method: 'get',
+      method: 'post',
       headers: {
         'Content-Type': 'application/json'
       },


### PR DESCRIPTION
## Requirements
Allowing users to find certificates requested by their counterparties will enable them to furnish such certificates upon request.

## Business / User Value
As a user, I want to search for any certificates that have been issued to me which would be acceptable to the people I am dealing with, so that I can earn their trust.

## Acceptance Criteria
**GIVEN** that a Dojo user wants to find certificates that comply with a `RequestedCertificateSet` (from the Authrite spec)
**WHEN** the Dojo user sends the `RequestedCertificateSet` to Dojo in a new `findCertificates` route
**THEN** Dojo searches for any certificates from the `certificates` table which belong to the user making the request, and which satisfy the constraints of the provided `RequestedCertificateSet`, returning them.

**GIVEN** that a Ninja user wants to use the Dojo route for finding certificates
**WHEN** they use the corresponding Ninja function
**THEN** they are able to provide all parameters accepted by the route, and obtain the response from the route

**GIVEN** that a consumer of the Babbage Desktop Port 3301 API wants to use the Ninja function
**WHEN** called with parameters corresponding to those that have been documented as part of Ninja
**THEN** the call to the Port 3301 API returns the expected results. Add new functionality to the Ninja controller to enable this.

**GIVEN** that a consumer of the Babbage SDK wants to use the `findCertificates` function
**WHEN** the SDK is called with appropriate corresponding parameters
**THEN** it uses the Port 3301 API, returning results with JSON (no “Primary Parameter”).
